### PR TITLE
feat: add new target "moongres"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,14 @@ default-members = ["./crates/*"]
 rust-version = "1.80"
 edition = "2021"
 
+[workspace.features]
+moongres = [
+    "moon/moongres",
+    "moonbuild/moongres",
+    "moonbuild-rupes-recta/moongres",
+    "moonutil/moongres",
+]
+
 [workspace.dependencies]
 n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "2cb2af63170acf3852c61326d5883a71f3576615" }
 arcstr = { version = "1.2", features = ["serde"] }

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -26,6 +26,13 @@ rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+moongres = [
+    "moonbuild/moongres",
+    "moonbuild-rupes-recta/moongres",
+    "moonutil/moongres",
+]
+
 [dependencies]
 moonbuild.workspace = true
 mooncake.workspace = true

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -244,6 +244,10 @@ fn run_single_mbt_file(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resu
                 TargetBackend::Wasm | TargetBackend::WasmGC => {
                     println!("moonrun {}", output_wasm_or_js_path.display());
                 }
+                #[cfg(feature = "moongres")]
+                TargetBackend::MoonGRES => {
+                    println!("rustica-engine run {}", output_wasm_or_js_path.display());
+                }
                 TargetBackend::Js => {
                     println!("node {}", output_wasm_or_js_path.display());
                 }
@@ -303,6 +307,10 @@ fn run_single_mbt_file(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resu
     trace::scope("run", || match target_backend {
         TargetBackend::Wasm | TargetBackend::WasmGC => {
             moonbuild::build::run_wat(&output_wasm_or_js_path, &cmd.args, cli.verbose)
+        }
+        #[cfg(feature = "moongres")]
+        TargetBackend::MoonGRES => {
+            moonbuild::build::run_moongres(&output_wasm_or_js_path, &cmd.args, cli.verbose)
         }
         TargetBackend::Js => {
             moonbuild::build::run_js(&output_wasm_or_js_path, &cmd.args, cli.verbose)

--- a/crates/moonbuild-rupes-recta/Cargo.toml
+++ b/crates/moonbuild-rupes-recta/Cargo.toml
@@ -22,6 +22,9 @@ version = "0.1.0"
 rust-version.workspace = true
 edition.workspace = true
 
+[features]
+moongres = [ "moonutil/moongres" ]
+
 [dependencies]
 moonutil.workspace = true
 mooncake.workspace = true

--- a/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
@@ -338,6 +338,10 @@ fn linked_core_artifact_ext(
     match backend {
         TargetBackend::Wasm | TargetBackend::WasmGC if wasm_use_wat => ".wat",
         TargetBackend::Wasm | TargetBackend::WasmGC => ".wasm",
+        #[cfg(feature = "moongres")]
+        TargetBackend::MoonGRES if wasm_use_wat => ".wat",
+        #[cfg(feature = "moongres")]
+        TargetBackend::MoonGRES => ".wasm",
         TargetBackend::Js => ".js",
         TargetBackend::Native => ".c",
         TargetBackend::LLVM => object_file_ext(os),
@@ -353,6 +357,10 @@ fn make_executable_artifact_ext(
     match backend {
         TargetBackend::Wasm | TargetBackend::WasmGC if wasm_use_wat => ".wat",
         TargetBackend::Wasm | TargetBackend::WasmGC => ".wasm",
+        #[cfg(feature = "moongres")]
+        TargetBackend::MoonGRES if wasm_use_wat => ".wat",
+        #[cfg(feature = "moongres")]
+        TargetBackend::MoonGRES => ".wasm",
         TargetBackend::Js => ".js",
         TargetBackend::Native | TargetBackend::LLVM => executable_ext(os, legacy_behavior),
     }

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/gen_test_driver.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/gen_test_driver.rs
@@ -123,6 +123,13 @@ impl<'a> CmdlineAbstraction for MoonGenTestDriver<'a> {
         // Configuration
         args.extend([
             "--target".to_string(),
+            // TODO(xenia): remove this after compiler support
+            #[cfg(feature = "moongres")]
+            match (args.first().map(|s| s.as_str()), self.target_backend) {
+                (Some("moon"), TargetBackend::MoonGRES) => "moongres".to_string(),
+                _ => self.target_backend.to_flag().to_string(),
+            },
+            #[cfg(not(feature = "moongres"))]
             self.target_backend.to_flag().to_string(),
         ]);
         args.extend(["--pkg-name".to_string(), self.pkg_name.to_string()]);

--- a/crates/moonbuild/Cargo.toml
+++ b/crates/moonbuild/Cargo.toml
@@ -24,6 +24,9 @@ rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+moongres = [ "moonutil/moongres" ]
+
 [dependencies]
 arcstr.workspace = true
 moonutil.workspace = true

--- a/crates/moonbuild/src/build.rs
+++ b/crates/moonbuild/src/build.rs
@@ -50,6 +50,20 @@ pub fn run_wat(path: &Path, args: &[String], verbose: bool) -> anyhow::Result<()
     run(cmd, verbose)
 }
 
+#[cfg(feature = "moongres")]
+pub fn run_moongres(path: &Path, args: &[String], verbose: bool) -> anyhow::Result<()> {
+    let mut cmd = Command::new(
+        crate::RUSTICA_ENGINE_EXECUTABLE
+            .as_deref()
+            .context("Unable to find the `rustica-engine` executable, please reinstall")?,
+    );
+    cmd.arg("run").arg(path);
+    if !args.is_empty() {
+        cmd.arg("--").args(args);
+    }
+    run(cmd, verbose)
+}
+
 pub fn run_js(path: &Path, args: &[String], verbose: bool) -> anyhow::Result<()> {
     let mut cmd = Command::new(
         NODE_EXECUTABLE

--- a/crates/moonbuild/src/dry_run.rs
+++ b/crates/moonbuild/src/dry_run.rs
@@ -75,6 +75,8 @@ pub fn print_run_commands(
             let mut watfile = state.graph.file(*fid).name.clone();
             let cmd = match target_backend {
                 TargetBackend::Wasm | TargetBackend::WasmGC => "moonrun ",
+                #[cfg(feature = "moongres")]
+                TargetBackend::MoonGRES => "rustica-engine run ",
                 TargetBackend::Js => "node ",
                 TargetBackend::Native | TargetBackend::LLVM => {
                     // stub.o would be default for native and llvm, skip them

--- a/crates/moonbuild/src/entry.rs
+++ b/crates/moonbuild/src/entry.rs
@@ -574,6 +574,10 @@ pub fn run_run(
         TargetBackend::Wasm | TargetBackend::WasmGC => {
             crate::build::run_wat(&wat_path, &moonbuild_opt.args, moonbuild_opt.verbose)
         }
+        #[cfg(feature = "moongres")]
+        TargetBackend::MoonGRES => {
+            crate::build::run_moongres(&wat_path, &moonbuild_opt.args, moonbuild_opt.verbose)
+        }
         TargetBackend::Js => {
             crate::build::run_js(&wat_path, &moonbuild_opt.args, moonbuild_opt.verbose)
         }
@@ -967,6 +971,17 @@ async fn execute_test(
         TargetBackend::Wasm | TargetBackend::WasmGC => {
             crate::runtest::run_wat(artifact_path, target_dir, args, file_test_info_map, verbose)
                 .await
+        }
+        #[cfg(feature = "moongres")]
+        TargetBackend::MoonGRES => {
+            crate::runtest::run_moongres(
+                artifact_path,
+                target_dir,
+                args,
+                file_test_info_map,
+                verbose,
+            )
+            .await
         }
         TargetBackend::Js => {
             crate::runtest::run_js(

--- a/crates/moonbuild/src/gen/gen_build.rs
+++ b/crates/moonbuild/src/gen/gen_build.rs
@@ -1509,6 +1509,8 @@ pub fn gen_n2_build_state(
                 let runtime = match moonc_opt.link_opt.target_backend {
                     TargetBackend::Native | TargetBackend::LLVM => "".to_string(),
                     TargetBackend::Wasm | TargetBackend::WasmGC => "moonrun".to_string(),
+                    #[cfg(feature = "moongres")]
+                    TargetBackend::MoonGRES => "rustica-engine run".to_string(),
                     TargetBackend::Js => "node".to_string(),
                 };
 

--- a/crates/moonbuild/src/lib.rs
+++ b/crates/moonbuild/src/lib.rs
@@ -98,8 +98,7 @@ static RUSTICA_ENGINE_EXECUTABLE: LazyLock<Option<std::path::PathBuf>> = LazyLoc
             let rv = candidates
                 .iter()
                 .map(|exe| exe_dir.join(exe))
-                .filter(|p| p.exists())
-                .next();
+                .find(|p| p.exists());
             if rv.is_some() {
                 return rv;
             }

--- a/crates/moonbuild/src/lib.rs
+++ b/crates/moonbuild/src/lib.rs
@@ -89,3 +89,22 @@ static PYTHON_EXECUTABLE: LazyLock<Option<std::path::PathBuf>> = LazyLock::new(|
         .iter()
         .find_map(|name| which::which(name).ok())
 });
+#[cfg(feature = "moongres")]
+static RUSTICA_ENGINE_EXECUTABLE: LazyLock<Option<std::path::PathBuf>> = LazyLock::new(|| {
+    let candidates = ["rustica-engine.exe", "rustica-engine"];
+    // Prefer the one next to the current executable
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(exe_dir) = current_exe.parent() {
+            let rv = candidates
+                .iter()
+                .map(|exe| exe_dir.join(exe))
+                .filter(|p| p.exists())
+                .next();
+            if rv.is_some() {
+                return rv;
+            }
+        }
+    }
+    // Fallback to search in PATH
+    candidates.iter().find_map(|exe| which::which(exe).ok())
+});

--- a/crates/moonbuild/src/runtest.rs
+++ b/crates/moonbuild/src/runtest.rs
@@ -81,6 +81,26 @@ pub async fn run_wat(
     run(path, cmd, target_dir, file_test_info_map, verbose).await
 }
 
+#[cfg(feature = "moongres")]
+pub async fn run_moongres(
+    path: &Path,
+    target_dir: &Path,
+    args: &TestArgs,
+    file_test_info_map: &FileTestInfo,
+    verbose: bool,
+) -> anyhow::Result<Vec<Result<TestStatistics, TestFailedStatus>>> {
+    let mut cmd = tokio::process::Command::new(
+        crate::RUSTICA_ENGINE_EXECUTABLE
+            .as_deref()
+            .context("Unable to find the `rustica-engine` executable, please reinstall")?,
+    );
+    cmd.arg("moontest")
+        .arg("--spec")
+        .arg(serde_json_lenient::to_string(args).expect("valid JSON"))
+        .arg(path);
+    run(path, cmd, target_dir, file_test_info_map, verbose).await
+}
+
 pub async fn run_js(
     path: &Path,
     target_dir: &Path,

--- a/crates/moonutil/Cargo.toml
+++ b/crates/moonutil/Cargo.toml
@@ -24,6 +24,9 @@ rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+moongres = []
+
 [dependencies]
 arcstr.workspace = true
 home.workspace = true

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -248,6 +248,9 @@ pub enum SurfaceTarget {
     Wasm,
     #[default]
     WasmGC,
+    #[cfg(feature = "moongres")]
+    #[value(name = "moongres")]
+    MoonGRES,
     Js,
     Native,
     LLVM,
@@ -264,6 +267,10 @@ pub fn lower_surface_targets(st: &[SurfaceTarget]) -> Vec<TargetBackend> {
             SurfaceTarget::WasmGC => {
                 result.insert(TargetBackend::WasmGC);
             }
+            #[cfg(feature = "moongres")]
+            SurfaceTarget::MoonGRES => {
+                result.insert(TargetBackend::MoonGRES);
+            }
             SurfaceTarget::Js => {
                 result.insert(TargetBackend::Js);
             }
@@ -276,6 +283,8 @@ pub fn lower_surface_targets(st: &[SurfaceTarget]) -> Vec<TargetBackend> {
             SurfaceTarget::All => {
                 result.insert(TargetBackend::Wasm);
                 result.insert(TargetBackend::WasmGC);
+                #[cfg(feature = "moongres")]
+                result.insert(TargetBackend::MoonGRES);
                 result.insert(TargetBackend::Js);
                 // todo: enable native backend
                 // result.insert(TargetBackend::Native);
@@ -294,6 +303,8 @@ pub enum TargetBackend {
     Wasm,
     #[default]
     WasmGC,
+    #[cfg(feature = "moongres")]
+    MoonGRES,
     Js,
     Native,
     LLVM
@@ -310,6 +321,8 @@ impl TargetBackend {
         match self {
             Self::Wasm => "wasm",
             Self::WasmGC => "wasm-gc",
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES => "wasm-gc", // TODO(xenia): change to moongres after compiler support
             Self::Js => "js",
             Self::Native => "native",
             Self::LLVM => "llvm",
@@ -320,6 +333,8 @@ impl TargetBackend {
         match self {
             Self::Wasm => "wasm",
             Self::WasmGC => "wasm",
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES => "wasm",
             Self::Js => "js",
             Self::Native => "exe",
             Self::LLVM => "exe",
@@ -330,6 +345,8 @@ impl TargetBackend {
         match self {
             Self::Wasm => "wasm",
             Self::WasmGC => "wasm",
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES => "wasm",
             Self::Js => "js",
             Self::Native => "c",
             Self::LLVM => O_EXT,
@@ -340,6 +357,8 @@ impl TargetBackend {
         match self {
             Self::Wasm => "wasm",
             Self::WasmGC => "wasm-gc",
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES => "moongres",
             Self::Js => "js",
             Self::Native => "native",
             Self::LLVM => "llvm",
@@ -350,6 +369,8 @@ impl TargetBackend {
         match self {
             Self::Wasm => "wasm",
             Self::WasmGC => "wasm-gc",
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES => "moongres",
             Self::Js => "js",
             Self::Native => "native",
             Self::LLVM => "llvm",
@@ -360,6 +381,8 @@ impl TargetBackend {
         match s {
             "wasm" => Ok(Self::Wasm),
             "wasm-gc" => Ok(Self::WasmGC),
+            #[cfg(feature = "moongres")]
+            "moongres" => Ok(Self::MoonGRES),
             "js" => Ok(Self::Js),
             "native" => Ok(Self::Native),
             "llvm" => Ok(Self::LLVM),
@@ -383,16 +406,28 @@ impl TargetBackend {
         match self {
             Self::Native | Self::LLVM => true,
             Self::Wasm | Self::WasmGC | Self::Js => false,
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES => false,
         }
     }
 
     pub fn all() -> &'static [Self] {
-        &[Self::Wasm, Self::WasmGC, Self::Js, Self::Native, Self::LLVM]
+        &[
+            Self::Wasm,
+            Self::WasmGC,
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES,
+            Self::Js,
+            Self::Native,
+            Self::LLVM,
+        ]
     }
 
     pub fn supports_source_map(&self) -> bool {
         match self {
             Self::WasmGC | Self::Js => true,
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES => true,
             Self::Wasm | Self::Native | Self::LLVM => false,
         }
     }
@@ -400,6 +435,8 @@ impl TargetBackend {
     pub fn is_wasm(&self) -> bool {
         match self {
             Self::Wasm | Self::WasmGC => true,
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES => true,
             Self::Js | Self::Native | Self::LLVM => false,
         }
     }
@@ -407,6 +444,8 @@ impl TargetBackend {
     pub fn allowed_as_project_target(&self) -> bool {
         match self {
             Self::Wasm | Self::WasmGC | Self::Js | Self::Native => true,
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES => true,
             Self::LLVM => false,
         }
     }

--- a/crates/moonutil/src/cond_expr.rs
+++ b/crates/moonutil/src/cond_expr.rs
@@ -86,6 +86,10 @@ impl CondExpr {
             (TargetBackend::Wasm, OptLevel::Release),
             (TargetBackend::WasmGC, OptLevel::Debug),
             (TargetBackend::WasmGC, OptLevel::Release),
+            #[cfg(feature = "moongres")]
+            (TargetBackend::MoonGRES, OptLevel::Debug),
+            #[cfg(feature = "moongres")]
+            (TargetBackend::MoonGRES, OptLevel::Release),
             (TargetBackend::Js, OptLevel::Debug),
             (TargetBackend::Js, OptLevel::Release),
             (TargetBackend::Native, OptLevel::Debug),
@@ -128,6 +132,8 @@ impl Default for CompileCondition {
             backend: vec![
                 TargetBackend::Wasm,
                 TargetBackend::WasmGC,
+                #[cfg(feature = "moongres")]
+                TargetBackend::MoonGRES,
                 TargetBackend::Js,
                 TargetBackend::Native,
                 TargetBackend::LLVM,
@@ -264,6 +270,8 @@ pub fn parse_cond_target(expr: &str) -> Result<CondExpr, ParseTargetError> {
         "debug" => Ok(CondExpr::Atom(Atom::OptLevel(OptLevel::Debug))),
         "wasm" => Ok(CondExpr::Atom(Atom::Target(TargetBackend::Wasm))),
         "wasm-gc" => Ok(CondExpr::Atom(Atom::Target(TargetBackend::WasmGC))),
+        #[cfg(feature = "moongres")]
+        "moongres" => Ok(CondExpr::Atom(Atom::Target(TargetBackend::MoonGRES))),
         "js" => Ok(CondExpr::Atom(Atom::Target(TargetBackend::Js))),
         "native" => Ok(CondExpr::Atom(Atom::Target(TargetBackend::Native))),
         "llvm" => Ok(CondExpr::Atom(Atom::Target(TargetBackend::LLVM))),
@@ -349,6 +357,8 @@ impl From<CondExpr> for StringOrArray {
                 Atom::Target(tb) => match tb {
                     TargetBackend::Wasm => StringOrArray::String("wasm".to_string()),
                     TargetBackend::WasmGC => StringOrArray::String("wasm-gc".to_string()),
+                    #[cfg(feature = "moongres")]
+                    TargetBackend::MoonGRES => StringOrArray::String("moongres".to_string()),
                     TargetBackend::Js => StringOrArray::String("js".to_string()),
                     TargetBackend::Native => StringOrArray::String("native".to_string()),
                     TargetBackend::LLVM => StringOrArray::String("llvm".to_string()),


### PR DESCRIPTION
This adds a new build target `moongres`, copying from the `wasm-gc` target, using the `rustica-engine` as runtime instead of `moonrun`, for landing future compiler/stdlib changes.

To test this PR, run:

```bash
cargo build --features moongres
cp target/debug/moon ~/.moon/bin/
cd ~/.moon/lib/core
moon test -v --target moongres --no-parallelize
```

Be sure to have the `rustica-engine` executable in your `PATH`.

Depends on:
- [x] moonbitlang/moon#1045
- [x] moonbitlang/moon#1047
- [x] https://github.com/rustica-lang/rustica-engine/commit/5fed3a1e8efc833efe280bcdd1a11ee9290bf166