### PR TITLE
fix: complete "moongres" target support

### DIFF
--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -224,6 +224,18 @@ const COMMON_TEMPLATE: &str = include_str!(concat!(
     "/../moonbuild/template/test_driver/common.mbt"
 ));
 
+#[cfg(feature = "moongres")]
+const MOONGRES_BENCH_DRIVER_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../moonbuild/template/test_driver/moongres/bench_driver_template.mbt"
+));
+
+#[cfg(feature = "moongres")]
+const MOONGRES_TEST_DRIVER_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../moonbuild/template/test_driver/moongres/test_driver_template.mbt"
+));
+
 fn generate_driver(
     data: &MooncGenTestInfo,
     pkgname: &str,
@@ -246,7 +258,13 @@ fn generate_driver(
         TEST_DRIVER_TEMPLATE
     };
     let mut template = template.to_string();
-    if !enable_bench {
+    if enable_bench {
+        #[cfg(feature = "moongres")]
+        template.push_str(MOONGRES_BENCH_DRIVER_TEMPLATE);
+    } else {
+        #[cfg(feature = "moongres")]
+        template.push_str(MOONGRES_TEST_DRIVER_TEMPLATE);
+
         if only_no_arg_tests {
             template.push_str(NO_ARGS_TEMPLATE)
         } else {

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -231,8 +231,12 @@ fn run_single_mbt_file(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resu
     };
 
     if cli.dry_run {
-        println!("moonc {}", build_package_command.join(" "));
-        println!("moonc {}", link_core_command.join(" "));
+        println!(
+            "{} {}",
+            target_backend.moonc(),
+            build_package_command.join(" ")
+        );
+        println!("{} {}", target_backend.moonc(), link_core_command.join(" "));
         if let Some(compile_exe_command) = compile_exe_command {
             println!("{}", compile_exe_command.join(" "));
         }
@@ -258,7 +262,7 @@ fn run_single_mbt_file(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resu
         return Ok(0);
     }
 
-    let moonc_build_package = std::process::Command::new("moonc")
+    let moonc_build_package = std::process::Command::new(target_backend.moonc())
         .args(&build_package_command)
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
@@ -266,10 +270,14 @@ fn run_single_mbt_file(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resu
         .wait()?;
 
     if !moonc_build_package.success() {
-        bail!("failed to run: moonc {}", build_package_command.join(" "))
+        bail!(
+            "failed to run: {} {}",
+            target_backend.moonc(),
+            build_package_command.join(" ")
+        )
     }
 
-    let moonc_link_core = std::process::Command::new("moonc")
+    let moonc_link_core = std::process::Command::new(target_backend.moonc())
         .args(&link_core_command)
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
@@ -277,7 +285,11 @@ fn run_single_mbt_file(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resu
         .wait()?;
 
     if !moonc_link_core.success() {
-        bail!("failed to run: moonc {}", link_core_command.join(" "))
+        bail!(
+            "failed to run: {} {}",
+            target_backend.moonc(),
+            link_core_command.join(" ")
+        )
     }
 
     if let Some(compile_exe_command) = compile_exe_command {

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/gen_test_driver.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/gen_test_driver.rs
@@ -123,13 +123,6 @@ impl<'a> CmdlineAbstraction for MoonGenTestDriver<'a> {
         // Configuration
         args.extend([
             "--target".to_string(),
-            // TODO(xenia): remove this after compiler support
-            #[cfg(feature = "moongres")]
-            match (args.first().map(|s| s.as_str()), self.target_backend) {
-                (Some("moon"), TargetBackend::MoonGRES) => "moongres".to_string(),
-                _ => self.target_backend.to_flag().to_string(),
-            },
-            #[cfg(not(feature = "moongres"))]
             self.target_backend.to_flag().to_string(),
         ]);
         args.extend(["--pkg-name".to_string(), self.pkg_name.to_string()]);

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -21,7 +21,7 @@
 use std::path::PathBuf;
 
 use log::debug;
-use moonutil::{common::TargetBackend, cond_expr::OptLevel, mooncakes::result::ResolvedEnv};
+use moonutil::{cond_expr::OptLevel, mooncakes::result::ResolvedEnv};
 use n2::graph::{Build, Graph as N2Graph};
 
 use crate::{

--- a/crates/moonbuild-rupes-recta/src/build_lower/lowering.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lowering.rs
@@ -89,7 +89,7 @@ impl<'a> BuildPlanLowerContext<'a> {
 
         BuildCommand {
             extra_inputs: files_vec.clone(),
-            commandline: cmd.build_command("moonc"),
+            commandline: cmd.build_command(self.opt.target_backend.moonc()),
         }
     }
 
@@ -149,7 +149,7 @@ impl<'a> BuildPlanLowerContext<'a> {
         // TODO: a lot of knobs are not controlled here
 
         BuildCommand {
-            commandline: cmd.build_command("moonc"),
+            commandline: cmd.build_command(self.opt.target_backend.moonc()),
             extra_inputs: files,
         }
     }
@@ -228,7 +228,7 @@ impl<'a> BuildPlanLowerContext<'a> {
 
         BuildCommand {
             extra_inputs: vec![],
-            commandline: cmd.build_command("moonc"),
+            commandline: cmd.build_command(self.opt.target_backend.moonc()),
         }
     }
 
@@ -476,7 +476,7 @@ impl<'a> BuildPlanLowerContext<'a> {
 
         BuildCommand {
             extra_inputs: vec![],
-            commandline: cmd.build_command("moonc"),
+            commandline: cmd.build_command(self.opt.target_backend.moonc()),
         }
     }
 

--- a/crates/moonbuild/src/gen/gen_build.rs
+++ b/crates/moonbuild/src/gen/gen_build.rs
@@ -402,7 +402,7 @@ pub fn gen_build_interface_command(
 
     let mut build = Build::new(loc, ins, outs);
 
-    let command = CommandBuilder::new("moonc")
+    let command = CommandBuilder::new(moonc_opt.build_opt.target_backend.moonc())
         .arg("build-interface")
         .arg(&item.mbti_deps)
         .arg("-o")
@@ -505,7 +505,7 @@ pub fn gen_build_command(
         moonc_opt.build_opt.strip_flag,
     );
 
-    let command = CommandBuilder::new("moonc")
+    let command = CommandBuilder::new(moonc_opt.build_opt.target_backend.moonc())
         .arg("build-package")
         .args_with_cond(moonc_opt.render, vec!["-error-format", "json"])
         .args_with_cond(
@@ -638,7 +638,7 @@ pub fn gen_link_command(
         moonc_opt.build_opt.strip_flag,
     );
 
-    let command = CommandBuilder::new("moonc")
+    let command = CommandBuilder::new(moonc_opt.link_opt.target_backend.moonc())
         .arg("link-core")
         .args(&item.core_deps)
         .arg("-main")

--- a/crates/moonbuild/src/gen/gen_bundle.rs
+++ b/crates/moonbuild/src/gen/gen_bundle.rs
@@ -219,7 +219,7 @@ pub fn gen_build_command(
         moonc_opt.build_opt.strip_flag,
     );
 
-    let command = CommandBuilder::new("moonc")
+    let command = CommandBuilder::new(moonc_opt.build_opt.target_backend.moonc())
         .arg("build-package")
         .args_with_cond(moonc_opt.render, vec!["-error-format", "json"])
         .args(&item.mbt_deps)
@@ -258,7 +258,7 @@ fn gen_bundle_all(
     graph: &mut n2graph::Graph,
     bundle_all: &N2BundleAll,
     target_dir: &Path,
-    _moonc_opt: &MooncOpt,
+    moonc_opt: &MooncOpt,
 ) -> Build {
     let loc = FileLoc {
         filename: Rc::new(PathBuf::from("bundle")),
@@ -290,7 +290,7 @@ fn gen_bundle_all(
 
     let mut build = Build::new(loc, ins, outs);
 
-    let command = CommandBuilder::new("moonc")
+    let command = CommandBuilder::new(moonc_opt.build_opt.target_backend.moonc())
         .arg("bundle-core")
         .args(bundle_all.order.iter())
         .arg("-o")

--- a/crates/moonbuild/src/gen/gen_check.rs
+++ b/crates/moonbuild/src/gen/gen_check.rs
@@ -528,7 +528,7 @@ pub fn gen_check_command(
 
     let mut build = Build::new(loc, ins, outs);
 
-    let command = CommandBuilder::new("moonc")
+    let command = CommandBuilder::new(moonc_opt.build_opt.target_backend.moonc())
         .arg("check")
         .arg_with_cond(item.patch_file.is_some(), "-patch-file")
         .lazy_args_with_cond(item.patch_file.is_some(), || {

--- a/crates/moonbuild/src/gen/gen_runtest.rs
+++ b/crates/moonbuild/src/gen/gen_runtest.rs
@@ -1174,7 +1174,7 @@ pub fn gen_runtest_build_command(
         moonc_opt.build_opt.strip_flag,
     );
 
-    let command = CommandBuilder::new("moonc")
+    let command = CommandBuilder::new(moonc_opt.build_opt.target_backend.moonc())
         .arg("build-package")
         .args_with_cond(moonc_opt.render, vec!["-error-format", "json"])
         .args(&item.mbt_deps)
@@ -1311,7 +1311,7 @@ pub fn gen_runtest_link_command(
         moonc_opt.build_opt.strip_flag,
     );
 
-    let command = CommandBuilder::new("moonc")
+    let command = CommandBuilder::new(moonc_opt.link_opt.target_backend.moonc())
         .arg("link-core")
         .args(&item.core_deps)
         .arg("-main")

--- a/crates/moonbuild/template/test_driver/common.mbt
+++ b/crates/moonbuild/template/test_driver/common.mbt
@@ -1,6 +1,6 @@
 fn moonbit_test_driver_internal_error_to_string(x : Error) -> String = "%error.to_string"
 
-#cfg(not(target="js"))
+#cfg(not(any(target="js", target="moongres")))
 fn moonbit_unsafe_char_from_int(x : Int) -> Char = "%identity"
 
 #cfg(target="native")

--- a/crates/moonbuild/template/test_driver/moongres/bench_driver_template.mbt
+++ b/crates/moonbuild/template/test_driver/moongres/bench_driver_template.mbt
@@ -1,0 +1,4 @@
+#cfg(target="moongres")
+pub fn moonbit_test_driver_internal_execute(filename : String, index : Int) -> Unit {
+  moonbit_test_driver_internal_do_execute(filename, index)
+}

--- a/crates/moonbuild/template/test_driver/moongres/test_driver_template.mbt
+++ b/crates/moonbuild/template/test_driver/moongres/test_driver_template.mbt
@@ -1,0 +1,6 @@
+#cfg(target="moongres")
+pub fn moonbit_test_driver_internal_execute(filename : String, index : Int) -> Unit {
+  moonbit_test_driver_internal_run_async_main(fn(ctx) {
+    moonbit_test_driver_internal_do_execute(ctx, filename, index)
+  })
+}

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -304,6 +304,7 @@ pub enum TargetBackend {
     #[default]
     WasmGC,
     #[cfg(feature = "moongres")]
+    #[value(name = "moongres")]
     MoonGRES,
     Js,
     Native,
@@ -322,7 +323,7 @@ impl TargetBackend {
             Self::Wasm => "wasm",
             Self::WasmGC => "wasm-gc",
             #[cfg(feature = "moongres")]
-            Self::MoonGRES => "wasm-gc", // TODO(xenia): change to moongres after compiler support
+            Self::MoonGRES => "moongres",
             Self::Js => "js",
             Self::Native => "native",
             Self::LLVM => "llvm",
@@ -435,6 +436,14 @@ impl TargetBackend {
             #[cfg(feature = "moongres")]
             Self::MoonGRES => true,
             Self::Wasm | Self::Native | Self::LLVM => false,
+        }
+    }
+
+    pub fn moonc(self) -> &'static str {
+        match self {
+            #[cfg(feature = "moongres")]
+            Self::MoonGRES => "mgresc",
+            _ => "moonc",
         }
     }
 


### PR DESCRIPTION
Now we have compiler support, drop the TODOs. Also fixed:

* TargetBackend value in clap
* test_driver template for the new target
* Use mgresc instead of moonc under new target

Refs #1 